### PR TITLE
Add files via upload

### DIFF
--- a/Grayscaling.ipynb
+++ b/Grayscaling.ipynb
@@ -1,0 +1,78 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cv2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#first method\n",
+    "\n",
+    "#1-load our input image\n",
+    "\n",
+    "img=cv2.imread('output.jpg')\n",
+    "cv2.imshow('original',img)\n",
+    "cv2.waitKey()\n",
+    "\n",
+    "#2-we use cvtcolor, to convert to grayscal\n",
+    "\n",
+    "gray_image= cv2.cvtColor(img,cv2.COLOR_BGR2GRAY)\n",
+    "\n",
+    "cv2.imshow('Grayscale',gray_image)\n",
+    "cv2.waitKey()\n",
+    "cv2.destroyAllWindows()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#fatest way to todo garyscaling\n",
+    "\n",
+    "img=cv2.imread('output.png',0)\n",
+    "cv2.imshow('original',img)\n",
+    "cv2.waitKey()\n",
+    "cv2.destroyAllWindows()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
_## Hey guys, been reading OpenCV for python and thought of posting a tutorial on Programming a Grayscale Image Convertor. I encourage you to google them , there are lots and lots of examples and code snippets. This is on how to a convert any image to gray scale using Python and OpenCV.
A sample input image and output image are shown below (YEah, I am big Iron Man Fan! :B). You can click on image to enlarge:_

`import cv2`

Then ,read the image to a variable named “image” :

`image = cv2.imread('ironman.png')`

Now, to convert to gray-scale image and store it to another variable named “gray_image” use the function cv2.cvtColor() with parameters as  the “image” variable and  “cv2.COLOR_BGR2GRAY” :

`gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)`

so, now the variable “gray_image” will hold the gray-scale version of the input image.

Now, to write/save the converted gray-scale image to the hard disk, we use the function “cv2.imwrite()” with parameters as “the name of converted image” and the variable “gray_image” to which the converted image was stored:

`cv2.imwrite('gray_image.png',gray_image)`

So, now if you open the directory where you saved your python code, you can see a new image there : gray_image.png! Wow! 😀

Now, to display the original and the gray-scale ,we use function “cv2.imshow()” with parameters as the “window title” and the “image variable” :

```
> cv2.imshow('color_image',image)             
> cv2.imshow('gray_image',gray_image) 
```

finaly:
Complete Code for GrayScale Image convertor:

# GrayScale Image Convertor
 
```
import cv2
image = cv2.imread('ironman.png')
gray_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
cv2.imwrite('gray_image.png',gray_image)
cv2.imshow('color_image',image)
cv2.imshow('gray_image',gray_image) 
cv2.waitKey(0)                 # Waits forever for user to press any key
cv2.destroyAllWindows()        # Closes displayed windows
 
#End of Code
```